### PR TITLE
feat: Add enhanced API rate limiting middleware [Bounty #88]

### DIFF
--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -1,0 +1,317 @@
+"""
+Enhanced Rate Limiting Middleware for WattCoin API
+v1.0.0 - Implements bounty issue #88
+
+Features:
+- Default 60 requests/minute per IP for public endpoints
+- Higher limits for authenticated/staked wallets
+- Rate limit headers in responses (X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset)
+- 429 Too Many Requests response with Retry-After header
+- Configurable via environment variables
+"""
+
+import os
+import time
+import logging
+from functools import wraps
+from flask import request, jsonify, g, make_response
+
+logger = logging.getLogger(__name__)
+
+# === Configuration from Environment Variables ===
+DEFAULT_RATE_LIMIT = int(os.getenv('RATE_LIMIT_DEFAULT', 60))  # requests per minute
+AUTHENTICATED_RATE_LIMIT = int(os.getenv('RATE_LIMIT_AUTHENTICATED', 200))  # requests per minute
+STAKED_RATE_LIMIT = int(os.getenv('RATE_LIMIT_STAKED', 500))  # requests per minute
+RATE_LIMIT_WINDOW = int(os.getenv('RATE_LIMIT_WINDOW', 60))  # seconds
+
+# Minimum stake to qualify for higher limits (in WATT)
+MIN_STAKE_FOR_BOOST = int(os.getenv('RATE_LIMIT_MIN_STAKE', 10000))
+
+
+def get_wallet_from_request():
+    """
+    Extract wallet address from request.
+    Checks Authorization header, X-Wallet header, and request body.
+    """
+    # Check Authorization header
+    auth = request.headers.get('Authorization', '')
+    if auth.startswith('Wallet '):
+        return auth[7:].strip()
+    
+    # Check X-Wallet header
+    wallet_header = request.headers.get('X-Wallet', '')
+    if wallet_header:
+        return wallet_header.strip()
+    
+    # Check request body
+    body = request.get_json(silent=True) or {}
+    wallet = body.get('wallet', '')
+    if wallet:
+        return wallet.strip()
+    
+    return None
+
+
+def check_wallet_stake(wallet):
+    """
+    Check if wallet has enough stake for boosted rate limits.
+    Returns stake amount in WATT.
+    """
+    if not wallet:
+        return 0
+    
+    try:
+        # Import from api_nodes to check stake
+        from api_nodes import load_nodes
+        nodes_data = load_nodes()
+        
+        # Check if wallet is a registered node with stake
+        for node_id, node in nodes_data.get('nodes', {}).items():
+            if node.get('wallet') == wallet:
+                return node.get('stake', 0)
+        
+        return 0
+    except Exception as e:
+        logger.debug("Could not check wallet stake: %s", e)
+        return 0
+
+
+def get_rate_limit_for_wallet(wallet):
+    """
+    Get appropriate rate limit based on wallet authentication and stake.
+    
+    Returns:
+        Tuple of (limit, tier_name)
+    """
+    if not wallet:
+        return DEFAULT_RATE_LIMIT, "public"
+    
+    stake = check_wallet_stake(wallet)
+    
+    if stake >= MIN_STAKE_FOR_BOOST:
+        return STAKED_RATE_LIMIT, "staked"
+    else:
+        return AUTHENTICATED_RATE_LIMIT, "authenticated"
+
+
+def add_rate_limit_headers(response, limit, remaining, reset_time):
+    """
+    Add rate limit headers to response.
+    
+    Headers:
+    - X-RateLimit-Limit: Maximum requests allowed in window
+    - X-RateLimit-Remaining: Requests remaining in current window
+    - X-RateLimit-Reset: Unix timestamp when window resets
+    """
+    response.headers['X-RateLimit-Limit'] = str(limit)
+    response.headers['X-RateLimit-Remaining'] = str(max(0, remaining))
+    response.headers['X-RateLimit-Reset'] = str(int(reset_time))
+    return response
+
+
+def create_429_response(retry_after, limit):
+    """
+    Create a properly formatted 429 Too Many Requests response.
+    """
+    response = make_response(jsonify({
+        "success": False,
+        "error": "rate_limit_exceeded",
+        "message": "Too many requests. Please slow down and try again later.",
+        "retry_after_seconds": retry_after,
+        "limit": limit,
+        "window_seconds": RATE_LIMIT_WINDOW
+    }), 429)
+    
+    response.headers['Retry-After'] = str(retry_after)
+    response.headers['X-RateLimit-Limit'] = str(limit)
+    response.headers['X-RateLimit-Remaining'] = '0'
+    response.headers['X-RateLimit-Reset'] = str(int(time.time() + retry_after))
+    
+    return response
+
+
+# === In-Memory Rate Limit Storage ===
+# For production, use Redis via Flask-Limiter's storage_uri
+_rate_buckets = {}
+
+
+def get_bucket_key(identifier, endpoint=None):
+    """Generate unique key for rate limit bucket."""
+    if endpoint:
+        return f"{identifier}:{endpoint}"
+    return identifier
+
+
+def check_rate_limit(identifier, limit):
+    """
+    Check and update rate limit for an identifier.
+    
+    Returns:
+        Tuple of (allowed, remaining, reset_time, retry_after)
+    """
+    current_time = time.time()
+    window_start = int(current_time / RATE_LIMIT_WINDOW) * RATE_LIMIT_WINDOW
+    window_end = window_start + RATE_LIMIT_WINDOW
+    
+    bucket_key = get_bucket_key(identifier)
+    
+    # Get or create bucket
+    if bucket_key not in _rate_buckets:
+        _rate_buckets[bucket_key] = {
+            "window_start": window_start,
+            "count": 0
+        }
+    
+    bucket = _rate_buckets[bucket_key]
+    
+    # Reset bucket if window has passed
+    if bucket["window_start"] < window_start:
+        bucket["window_start"] = window_start
+        bucket["count"] = 0
+    
+    # Check if limit exceeded
+    if bucket["count"] >= limit:
+        retry_after = int(window_end - current_time)
+        return False, 0, window_end, max(1, retry_after)
+    
+    # Increment counter
+    bucket["count"] += 1
+    remaining = limit - bucket["count"]
+    
+    return True, remaining, window_end, 0
+
+
+def rate_limit_middleware():
+    """
+    Flask before_request handler for rate limiting.
+    
+    To enable, add to your Flask app:
+        from rate_limiter import rate_limit_middleware
+        app.before_request(rate_limit_middleware)
+    """
+    # Skip rate limiting for health checks and static files
+    if request.path in ('/api/v1/health', '/health', '/favicon.ico'):
+        return None
+    
+    # Skip for internal/admin routes
+    if request.path.startswith('/admin'):
+        return None
+    
+    # Get identifier (wallet or IP)
+    wallet = get_wallet_from_request()
+    if wallet:
+        identifier = f"wallet:{wallet}"
+    else:
+        identifier = f"ip:{request.remote_addr}"
+    
+    # Get appropriate rate limit
+    limit, tier = get_rate_limit_for_wallet(wallet)
+    
+    # Check rate limit
+    allowed, remaining, reset_time, retry_after = check_rate_limit(identifier, limit)
+    
+    # Store for after_request handler
+    g.rate_limit_info = {
+        "limit": limit,
+        "remaining": remaining,
+        "reset_time": reset_time,
+        "tier": tier
+    }
+    
+    if not allowed:
+        logger.warning(
+            "Rate limit exceeded | identifier=%s tier=%s limit=%d path=%s",
+            identifier[:20], tier, limit, request.path
+        )
+        return create_429_response(retry_after, limit)
+    
+    return None
+
+
+def rate_limit_after_request(response):
+    """
+    Flask after_request handler to add rate limit headers.
+    
+    To enable, add to your Flask app:
+        from rate_limiter import rate_limit_after_request
+        app.after_request(rate_limit_after_request)
+    """
+    info = getattr(g, 'rate_limit_info', None)
+    if info:
+        add_rate_limit_headers(
+            response,
+            info["limit"],
+            info["remaining"],
+            info["reset_time"]
+        )
+    return response
+
+
+def rate_limit(limit=None, per_minute=True):
+    """
+    Decorator for custom rate limiting on specific endpoints.
+    
+    Usage:
+        @app.route('/api/expensive')
+        @rate_limit(limit=10)
+        def expensive_endpoint():
+            ...
+    
+    Args:
+        limit: Max requests allowed (default: use tier-based limit)
+        per_minute: If True, limit is per minute (default: True)
+    """
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            wallet = get_wallet_from_request()
+            
+            if limit:
+                effective_limit = limit
+                tier = "custom"
+            else:
+                effective_limit, tier = get_rate_limit_for_wallet(wallet)
+            
+            if wallet:
+                identifier = f"wallet:{wallet}:{request.endpoint}"
+            else:
+                identifier = f"ip:{request.remote_addr}:{request.endpoint}"
+            
+            allowed, remaining, reset_time, retry_after = check_rate_limit(
+                identifier, effective_limit
+            )
+            
+            if not allowed:
+                logger.warning(
+                    "Rate limit exceeded (decorator) | endpoint=%s tier=%s limit=%d",
+                    request.endpoint, tier, effective_limit
+                )
+                return create_429_response(retry_after, effective_limit)
+            
+            response = make_response(f(*args, **kwargs))
+            add_rate_limit_headers(response, effective_limit, remaining, reset_time)
+            return response
+        
+        return decorated_function
+    return decorator
+
+
+# === Cleanup Task ===
+def cleanup_expired_buckets():
+    """
+    Remove expired rate limit buckets to prevent memory growth.
+    Call periodically (e.g., every 5 minutes).
+    """
+    current_time = time.time()
+    window_start = int(current_time / RATE_LIMIT_WINDOW) * RATE_LIMIT_WINDOW
+    
+    expired_keys = [
+        key for key, bucket in _rate_buckets.items()
+        if bucket["window_start"] < window_start - RATE_LIMIT_WINDOW
+    ]
+    
+    for key in expired_keys:
+        del _rate_buckets[key]
+    
+    if expired_keys:
+        logger.debug("Cleaned up %d expired rate limit buckets", len(expired_keys))

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,279 @@
+"""
+Tests for the enhanced rate limiter middleware.
+"""
+
+import pytest
+import json
+import os
+import sys
+import time
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from rate_limiter import (
+    get_wallet_from_request,
+    check_wallet_stake,
+    get_rate_limit_for_wallet,
+    add_rate_limit_headers,
+    check_rate_limit,
+    cleanup_expired_buckets,
+    DEFAULT_RATE_LIMIT,
+    AUTHENTICATED_RATE_LIMIT,
+    STAKED_RATE_LIMIT,
+    _rate_buckets
+)
+
+
+class TestGetWalletFromRequest:
+    """Tests for wallet extraction from request."""
+    
+    def test_wallet_from_authorization_header(self):
+        """Test extracting wallet from Authorization header."""
+        with patch('rate_limiter.request') as mock_request:
+            mock_request.headers = {'Authorization': 'Wallet ABC123'}
+            mock_request.get_json.return_value = None
+            
+            result = get_wallet_from_request()
+            assert result == 'ABC123'
+    
+    def test_wallet_from_x_wallet_header(self):
+        """Test extracting wallet from X-Wallet header."""
+        with patch('rate_limiter.request') as mock_request:
+            mock_request.headers = {'X-Wallet': 'DEF456'}
+            mock_request.get_json.return_value = None
+            
+            result = get_wallet_from_request()
+            assert result == 'DEF456'
+    
+    def test_wallet_from_body(self):
+        """Test extracting wallet from request body."""
+        with patch('rate_limiter.request') as mock_request:
+            mock_request.headers = {}
+            mock_request.get_json.return_value = {'wallet': 'GHI789'}
+            
+            result = get_wallet_from_request()
+            assert result == 'GHI789'
+    
+    def test_no_wallet(self):
+        """Test when no wallet is provided."""
+        with patch('rate_limiter.request') as mock_request:
+            mock_request.headers = {}
+            mock_request.get_json.return_value = {}
+            
+            result = get_wallet_from_request()
+            assert result is None
+
+
+class TestGetRateLimitForWallet:
+    """Tests for tier-based rate limits."""
+    
+    def test_public_rate_limit(self):
+        """Test rate limit for unauthenticated requests."""
+        limit, tier = get_rate_limit_for_wallet(None)
+        assert limit == DEFAULT_RATE_LIMIT
+        assert tier == "public"
+    
+    @patch('rate_limiter.check_wallet_stake')
+    def test_authenticated_rate_limit(self, mock_stake):
+        """Test rate limit for authenticated wallets without stake."""
+        mock_stake.return_value = 0
+        
+        limit, tier = get_rate_limit_for_wallet("SomeWallet123")
+        assert limit == AUTHENTICATED_RATE_LIMIT
+        assert tier == "authenticated"
+    
+    @patch('rate_limiter.check_wallet_stake')
+    def test_staked_rate_limit(self, mock_stake):
+        """Test rate limit for staked wallets."""
+        mock_stake.return_value = 15000  # Above MIN_STAKE_FOR_BOOST
+        
+        limit, tier = get_rate_limit_for_wallet("StakedWallet")
+        assert limit == STAKED_RATE_LIMIT
+        assert tier == "staked"
+
+
+class TestCheckRateLimit:
+    """Tests for rate limit checking."""
+    
+    def setup_method(self):
+        """Clear rate buckets before each test."""
+        _rate_buckets.clear()
+    
+    def test_first_request_allowed(self):
+        """Test that first request is always allowed."""
+        allowed, remaining, reset_time, retry_after = check_rate_limit("test_id", 60)
+        
+        assert allowed is True
+        assert remaining == 59
+        assert retry_after == 0
+    
+    def test_limit_exhaustion(self):
+        """Test that requests are blocked when limit is exhausted."""
+        limit = 5
+        
+        # Make limit requests
+        for i in range(limit):
+            allowed, remaining, _, _ = check_rate_limit("exhaust_test", limit)
+            assert allowed is True
+            assert remaining == limit - i - 1
+        
+        # Next request should be blocked
+        allowed, remaining, reset_time, retry_after = check_rate_limit("exhaust_test", limit)
+        assert allowed is False
+        assert remaining == 0
+        assert retry_after > 0
+    
+    def test_different_identifiers(self):
+        """Test that different identifiers have separate limits."""
+        allowed1, remaining1, _, _ = check_rate_limit("user_a", 10)
+        allowed2, remaining2, _, _ = check_rate_limit("user_b", 10)
+        
+        assert allowed1 is True
+        assert allowed2 is True
+        assert remaining1 == 9
+        assert remaining2 == 9
+
+
+class TestRateLimitHeaders:
+    """Tests for rate limit response headers."""
+    
+    def test_headers_added(self):
+        """Test that rate limit headers are added to response."""
+        mock_response = MagicMock()
+        mock_response.headers = {}
+        
+        result = add_rate_limit_headers(mock_response, 60, 45, 1707300000)
+        
+        assert result.headers['X-RateLimit-Limit'] == '60'
+        assert result.headers['X-RateLimit-Remaining'] == '45'
+        assert result.headers['X-RateLimit-Reset'] == '1707300000'
+    
+    def test_remaining_not_negative(self):
+        """Test that remaining is never negative."""
+        mock_response = MagicMock()
+        mock_response.headers = {}
+        
+        add_rate_limit_headers(mock_response, 60, -5, 1707300000)
+        
+        assert mock_response.headers['X-RateLimit-Remaining'] == '0'
+
+
+class TestCleanupExpiredBuckets:
+    """Tests for bucket cleanup."""
+    
+    def test_cleanup_removes_old_buckets(self):
+        """Test that old buckets are cleaned up."""
+        _rate_buckets.clear()
+        
+        # Add an expired bucket
+        _rate_buckets["old_bucket"] = {
+            "window_start": time.time() - 300,  # 5 minutes ago
+            "count": 50
+        }
+        
+        # Add a current bucket
+        current_window = int(time.time() / 60) * 60
+        _rate_buckets["current_bucket"] = {
+            "window_start": current_window,
+            "count": 10
+        }
+        
+        cleanup_expired_buckets()
+        
+        assert "old_bucket" not in _rate_buckets
+        assert "current_bucket" in _rate_buckets
+
+
+class TestEnvironmentVariables:
+    """Tests for environment variable configuration."""
+    
+    def test_default_values(self):
+        """Test default configuration values."""
+        assert DEFAULT_RATE_LIMIT == int(os.getenv('RATE_LIMIT_DEFAULT', 60))
+        assert AUTHENTICATED_RATE_LIMIT == int(os.getenv('RATE_LIMIT_AUTHENTICATED', 200))
+        assert STAKED_RATE_LIMIT == int(os.getenv('RATE_LIMIT_STAKED', 500))
+
+
+@pytest.fixture
+def client():
+    """Create test client with rate limiter middleware."""
+    os.environ['DATA_DIR'] = '/tmp/wattcoin_test_data'
+    os.makedirs('/tmp/wattcoin_test_data', exist_ok=True)
+    
+    from flask import Flask
+    from rate_limiter import rate_limit_middleware, rate_limit_after_request
+    
+    app = Flask(__name__)
+    app.before_request(rate_limit_middleware)
+    app.after_request(rate_limit_after_request)
+    
+    @app.route('/api/v1/test')
+    def test_endpoint():
+        return {"success": True}
+    
+    @app.route('/api/v1/health')
+    def health():
+        return {"status": "healthy"}
+    
+    app.config['TESTING'] = True
+    
+    _rate_buckets.clear()
+    
+    with app.test_client() as client:
+        yield client
+    
+    import shutil
+    if os.path.exists('/tmp/wattcoin_test_data'):
+        shutil.rmtree('/tmp/wattcoin_test_data')
+
+
+def test_middleware_adds_headers(client):
+    """Test that middleware adds rate limit headers."""
+    response = client.get('/api/v1/test')
+    
+    assert 'X-RateLimit-Limit' in response.headers
+    assert 'X-RateLimit-Remaining' in response.headers
+    assert 'X-RateLimit-Reset' in response.headers
+
+
+def test_middleware_skips_health(client):
+    """Test that health endpoint is not rate limited."""
+    # Make many requests to health endpoint
+    for _ in range(100):
+        response = client.get('/api/v1/health')
+        assert response.status_code == 200
+
+
+def test_middleware_returns_429(client):
+    """Test that 429 is returned when limit exceeded."""
+    _rate_buckets.clear()
+    
+    # Exhaust the limit (default 60)
+    for i in range(60):
+        response = client.get('/api/v1/test')
+        assert response.status_code == 200
+    
+    # Next request should be 429
+    response = client.get('/api/v1/test')
+    assert response.status_code == 429
+    assert 'Retry-After' in response.headers
+    
+    data = json.loads(response.data)
+    assert data['error'] == 'rate_limit_exceeded'
+    assert 'retry_after_seconds' in data
+
+
+def test_authenticated_gets_higher_limit(client):
+    """Test that authenticated requests get higher limits."""
+    _rate_buckets.clear()
+    
+    # Make requests with wallet header
+    for i in range(65):  # More than public limit (60)
+        response = client.get(
+            '/api/v1/test',
+            headers={'X-Wallet': 'TestWallet123'}
+        )
+        # Authenticated limit is 200, so should still be allowed
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
Implements comprehensive rate limiting middleware as specified in issue #88.

## New File
- `rate_limiter.py` - Standalone middleware module
- `tests/test_rate_limiter.py` - 15 test cases

## Features
✅ Default: 60 requests/minute per IP for public endpoints
✅ Higher limits for authenticated/staked wallets
✅ Rate limit headers in responses
✅ 429 Too Many Requests with Retry-After header
✅ Configurable via environment variables
✅ Does NOT modify existing endpoint logic

## Rate Limit Tiers
| Tier | Limit | Condition |
|------|-------|-----------|
| Public | 60/min | No wallet provided |
| Authenticated | 200/min | Wallet in request |
| Staked | 500/min | Wallet has ≥10K WATT stake |

## Response Headers
All responses include:
```
X-RateLimit-Limit: 60
X-RateLimit-Remaining: 45
X-RateLimit-Reset: 1707300060
```

## 429 Response Format
```json
{
  "success": false,
  "error": "rate_limit_exceeded",
  "message": "Too many requests. Please slow down and try again later.",
  "retry_after_seconds": 30,
  "limit": 60,
  "window_seconds": 60
}
```
With `Retry-After: 30` header.

## Environment Variables
| Variable | Default | Description |
|----------|---------|-------------|
| RATE_LIMIT_DEFAULT | 60 | Public limit per minute |
| RATE_LIMIT_AUTHENTICATED | 200 | Authenticated limit |
| RATE_LIMIT_STAKED | 500 | Staked wallet limit |
| RATE_LIMIT_WINDOW | 60 | Window size in seconds |
| RATE_LIMIT_MIN_STAKE | 10000 | Min stake for boost |

## Usage
```python
from rate_limiter import rate_limit_middleware, rate_limit_after_request
app.before_request(rate_limit_middleware)
app.after_request(rate_limit_after_request)
```

## Tests
15 test cases covering:
- Wallet extraction (Authorization, X-Wallet, body)
- Tier-based limits
- Rate limit exhaustion
- Header addition
- 429 response format
- Health endpoint bypass
- Bucket cleanup

Closes #88