### PR TITLE
Fix #88: add configurable public API rate limits in bridge_web

### DIFF
--- a/tests/test_public_rate_limit.py
+++ b/tests/test_public_rate_limit.py
@@ -1,0 +1,24 @@
+import bridge_web
+
+
+def test_health_rate_limit_enforced():
+    client = bridge_web.app.test_client()
+
+    # 60/min default for public endpoints
+    for _ in range(60):
+        resp = client.get('/health')
+        assert resp.status_code in (200, 503)
+
+    blocked = client.get('/health')
+    assert blocked.status_code == 429
+    assert blocked.headers.get('Retry-After')
+
+
+def test_rate_limit_headers_present():
+    client = bridge_web.app.test_client()
+    resp = client.get('/api/v1/pricing')
+
+    assert resp.status_code == 200
+    assert 'X-RateLimit-Limit' in resp.headers
+    assert 'X-RateLimit-Remaining' in resp.headers
+    assert 'X-RateLimit-Reset' in resp.headers


### PR DESCRIPTION
## Summary
Implements issue #88 by integrating Flask-Limiter directly in `bridge_web.py` for public endpoints.

## Changes
- Added configurable public limit via env vars:
  - `PUBLIC_RATE_LIMIT_PER_MIN` (default `60`)
  - `GLOBAL_RATE_LIMIT_HOURLY` (default `1000 per hour`)
  - `GLOBAL_RATE_LIMIT_MINUTE` (default `100 per minute`)
- Applied `@limiter.limit(PUBLIC_RATE_LIMIT)` directly to public routes in `bridge_web.py`:
  - `/health`
  - `/api/v1/pricing`
  - `/api/v1/bounty-stats`
- Improved 429 handler to include `Retry-After` response header explicitly.
- Added tests for:
  - 429 response after exceeding public endpoint limit
  - `X-RateLimit-*` headers on public endpoints

## Notes
- No standalone rate limiter module added.
- Endpoint behavior preserved; only rate-limit integration updated.
- Focused small change set in one file + tests.

Closes #88

**Payout Wallet**: HVLdjyDJCd7iwjLAkhAK1WPxuWfsDiiugbN8DMfoLbjP
