### PR TITLE
Fix #90: extend existing /health endpoint with service-level checks

### DIFF
--- a/bridge_web.py
+++ b/bridge_web.py
@@ -1398,16 +1398,39 @@ def proxy_moltbook():
 
 @app.route('/health')
 def health():
+    data_dir = os.getenv('DATA_DIR', '/app/data')
+    tasks_file = os.path.join(data_dir, 'tasks.json')
+    bounties_file = os.path.join(data_dir, 'bounties.json')
+
+    files_ok = all([
+        os.path.exists(tasks_file),
+        os.path.exists(bounties_file),
+        os.access(tasks_file, os.R_OK),
+        os.access(bounties_file, os.R_OK)
+    ])
+    discord_ok = bool(os.getenv('DISCORD_WEBHOOK'))
+    ai_ok = bool(os.getenv('AI_API_KEY'))
+
+    services = {
+        'data_files': 'ok' if files_ok else 'degraded',
+        'discord': 'ok' if discord_ok else 'degraded',
+        'ai_api': 'ok' if ai_ok else 'degraded'
+    }
+
     active_nodes = len(get_active_nodes())
+    open_tasks = len([t for t in load_tasks() if t.get('status') == 'open'])
+
+    healthy = all(v == 'ok' for v in services.values())
+    status_code = 200 if healthy else 503
+
     return jsonify({
-        'status': 'ok', 
+        'status': 'healthy' if healthy else 'degraded',
         'version': '3.4.0',
-        'ai': bool(ai_client), 
-        'claude': bool(claude_client),
-        'proxy': True,
-        'admin': True,
-        'active_nodes': active_nodes
-    })
+        'services': services,
+        'active_nodes': active_nodes,
+        'open_tasks': open_tasks,
+        'timestamp': datetime.utcnow().isoformat() + 'Z'
+    }), status_code
 
 
 @app.route('/api/v1/pricing', methods=['GET'])

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,0 +1,27 @@
+import bridge_web
+
+
+def _run_health(monkeypatch, exists, webhook, ai_key, nodes, tasks):
+    monkeypatch.setattr(bridge_web.os, "getenv", lambda k, d=None: {
+        "DATA_DIR": "/tmp/data", "DISCORD_WEBHOOK": webhook, "AI_API_KEY": ai_key
+    }.get(k, d))
+    monkeypatch.setattr(bridge_web.os.path, "exists", lambda _p: exists)
+    monkeypatch.setattr(bridge_web.os, "access", lambda _p, _m: exists)
+    monkeypatch.setattr(bridge_web, "get_active_nodes", lambda: nodes)
+    monkeypatch.setattr(bridge_web, "load_tasks", lambda: tasks)
+    resp = bridge_web.app.test_client().get("/health")
+    return resp.get_json(), resp.status_code
+
+
+def test_health_healthy(monkeypatch):
+    data, code = _run_health(monkeypatch, True, "https://discord.test/webhook", "key", ["n1", "n2"], [{"status": "open"}, {"status": "claimed"}])
+    assert code == 200 and data["status"] == "healthy"
+    assert data["services"] == {"data_files": "ok", "discord": "ok", "ai_api": "ok"}
+    assert data["active_nodes"] == 2 and data["open_tasks"] == 1
+
+
+def test_health_degraded(monkeypatch):
+    data, code = _run_health(monkeypatch, False, "", "", [], [])
+    assert code == 503 and data["status"] == "degraded"
+    assert data["services"] == {"data_files": "degraded", "discord": "degraded", "ai_api": "degraded"}
+    assert data["active_nodes"] == 0 and data["open_tasks"] == 0


### PR DESCRIPTION
## Summary
Extends the existing `/health` route in `bridge_web.py` with lightweight service checks and status semantics required by #90.

## What changed
- Modified existing `/health` endpoint (no new blueprint/file)
- Added lightweight checks only:
  - data files readable (`tasks.json`, `bounties.json`)
  - Discord webhook configured
  - AI API key present
- Added response fields:
  - `services` object with per-service status
  - `active_nodes` count
  - `open_tasks` count
  - `timestamp`
- Returns:
  - `200` when all services are healthy
  - `503` when any critical service is degraded
- Added focused health tests using monkeypatch only (`tests/test_health_endpoint.py`)

## Notes
- No outbound calls in health checks.
- Change set remains focused and small.

Closes #90

**Payout Wallet**: HVLdjyDJCd7iwjLAkhAK1WPxuWfsDiiugbN8DMfoLbjP
