### PR TITLE
feat(wattnode): add Linux GUI build script and AppImage packaging path

### DIFF
--- a/wattnode/README.md
+++ b/wattnode/README.md
@@ -4,16 +4,21 @@
 
 WattNode connects to the WattCoin network and fulfills jobs (web scraping, AI inference) for requesters. You earn **70%** of each job's payment in WATT.
 
-## 🖥️ Windows GUI (Recommended for Desktop)
+## 🖥️ Desktop GUI (Windows + Linux)
 
-For a point-and-click experience, use the Windows GUI app:
+For a point-and-click experience, use the WattNode GUI app:
 
-**[Download WattNode-Setup.exe](https://github.com/WattCoin-Org/wattcoin/releases)** or run from source:
+**[Download WattNode-Setup.exe](https://github.com/WattCoin-Org/wattcoin/releases)** (Windows) or run from source:
 
-```powershell
+```bash
 cd wattnode
 pip install -r requirements_gui.txt
 python wattnode_gui.py
+```
+
+Linux package build:
+```bash
+python build_linux.py
 ```
 
 See [README_GUI.md](README_GUI.md) for full GUI documentation.

--- a/wattnode/README_GUI.md
+++ b/wattnode/README_GUI.md
@@ -1,6 +1,6 @@
-# WattNode Windows GUI
+# WattNode Desktop GUI
 
-A desktop application to run WattNode and earn WATT.
+A desktop application to run WattNode and earn WATT on Windows and Linux.
 
 ![WattNode GUI](assets/screenshot.png)
 
@@ -27,28 +27,45 @@ pip install -r requirements_gui.txt
 python wattnode_gui.py
 ```
 
-## Building the Installer
+## Linux Quick Start
 
-### Prerequisites
+```bash
+cd wattnode
+pip install -r requirements_gui.txt
+python wattnode_gui.py
+```
+
+## Building Packages
+
+### Windows (EXE + Inno Setup installer)
+
+Prerequisites:
 - Python 3.9+
-- [Inno Setup](https://jrsoftware.org/isdl.php) (for creating installer)
+- [Inno Setup](https://jrsoftware.org/isdl.php)
 
-### Steps
 ```powershell
 cd wattnode
-
-# 1. Add logo to assets folder
-mkdir assets
-# Copy wattcoin_logo.png to assets/logo.png
-
-# 2. Build executable
 python build_windows.py
-
-# 3. Create installer (open in Inno Setup)
-# File → Open → installer.iss → Build → Compile
+# Then build installer.iss with Inno Setup
 ```
 
 Output: `installer_output/WattNode-Setup-1.0.0.exe`
+
+### Linux (single-file binary + AppImage)
+
+Prerequisites:
+- Python 3.9+
+- `pip install pyinstaller`
+- Optional: `appimagetool` for AppImage packaging
+
+```bash
+cd wattnode
+python build_linux.py
+```
+
+Outputs:
+- `dist/WattNode` (one-file Linux binary)
+- `dist/WattNode.AppImage` (if appimagetool is installed)
 
 ## Features
 
@@ -89,7 +106,8 @@ Your stake ensures network integrity. Nodes earn 70% of each job payment.
 | File | Description |
 |------|-------------|
 | `wattnode_gui.py` | Main GUI application |
-| `build_windows.py` | PyInstaller build script |
+| `build_windows.py` | Windows PyInstaller build script |
+| `build_linux.py` | Linux one-file + AppImage build script |
 | `installer.iss` | Inno Setup installer script |
 | `requirements_gui.txt` | Python dependencies |
 | `assets/logo.png` | WattCoin logo |

--- a/wattnode/build_linux.py
+++ b/wattnode/build_linux.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Build WattNode Linux GUI artifacts.
+
+Produces:
+- dist/WattNode (one-file PyInstaller binary)
+- dist/WattNode.AppImage (when appimagetool is available)
+
+Run:
+  python build_linux.py
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.resolve()
+DIST = ROOT / "dist"
+APPDIR = ROOT / "AppDir"
+
+
+def run(cmd):
+    print("+", " ".join(map(str, cmd)))
+    subprocess.run(cmd, check=True)
+
+
+def ensure_pyinstaller():
+    try:
+        import PyInstaller  # noqa: F401
+    except Exception:
+        run([sys.executable, "-m", "pip", "install", "pyinstaller"])
+
+
+def build_onefile():
+    data_sep = ":"
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--onefile",
+        "--windowed",
+        "--name=WattNode",
+        f"--add-data=assets{data_sep}assets",
+        "wattnode_gui.py",
+    ]
+    png_icon = ROOT / "assets" / "logo.png"
+    if png_icon.exists():
+        cmd.append(f"--icon={png_icon}")
+    run(cmd)
+
+
+def make_apprun():
+    apprun = APPDIR / "AppRun"
+    apprun.write_text("#!/bin/sh\nexec \"$(dirname \"$0\")/usr/bin/WattNode\" \"$@\"\n", encoding="utf-8")
+    apprun.chmod(apprun.stat().st_mode | stat.S_IEXEC)
+
+
+def stage_appdir():
+    if APPDIR.exists():
+        shutil.rmtree(APPDIR)
+    (APPDIR / "usr" / "bin").mkdir(parents=True, exist_ok=True)
+    (APPDIR / "usr" / "share" / "applications").mkdir(parents=True, exist_ok=True)
+    (APPDIR / "usr" / "share" / "icons" / "hicolor" / "256x256" / "apps").mkdir(parents=True, exist_ok=True)
+
+    shutil.copy2(DIST / "WattNode", APPDIR / "usr" / "bin" / "WattNode")
+
+    desktop = """[Desktop Entry]
+Type=Application
+Name=WattNode
+Exec=WattNode
+Icon=wattnode
+Categories=Utility;
+Terminal=false
+"""
+    (APPDIR / "wattnode.desktop").write_text(desktop, encoding="utf-8")
+    (APPDIR / "usr" / "share" / "applications" / "wattnode.desktop").write_text(desktop, encoding="utf-8")
+
+    icon_src = ROOT / "assets" / "logo.png"
+    if icon_src.exists():
+        shutil.copy2(icon_src, APPDIR / "wattnode.png")
+        shutil.copy2(icon_src, APPDIR / "usr" / "share" / "icons" / "hicolor" / "256x256" / "apps" / "wattnode.png")
+
+    make_apprun()
+
+
+def build_appimage():
+    appimagetool = shutil.which("appimagetool")
+    if not appimagetool:
+        print("! appimagetool not found. Skipping AppImage packaging.")
+        print("  Install: https://appimage.github.io/appimagetool/")
+        return
+    DIST.mkdir(exist_ok=True)
+    out = DIST / "WattNode.AppImage"
+    run([appimagetool, str(APPDIR), str(out)])
+    print(f"✓ AppImage created: {out}")
+
+
+def main():
+    os.chdir(ROOT)
+    print("=" * 50)
+    print("WattNode Linux Build")
+    print("=" * 50)
+    ensure_pyinstaller()
+    build_onefile()
+    stage_appdir()
+    build_appimage()
+    print("\n✓ Linux build complete")
+    print("- Binary: dist/WattNode")
+    if (DIST / "WattNode.AppImage").exists():
+        print("- AppImage: dist/WattNode.AppImage")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Implements the packaging/build portion of #138 for WattNode Linux GUI delivery with a reproducible script.

## What changed
- Added `wattnode/build_linux.py` to build:
  - `dist/WattNode` (PyInstaller one-file Linux binary)
  - `dist/WattNode.AppImage` (when `appimagetool` is available)
- Added AppDir staging and desktop/icon metadata generation for AppImage packaging
- Updated `wattnode/README_GUI.md` with Linux run/build instructions and outputs
- Updated `wattnode/README.md` GUI section to include Linux build flow

## Notes
- Existing Linux NVIDIA detection remains in `NodeService._check_gpu()` via `nvidia-smi`
- No destructive changes to runtime flow; this is additive build/documentation work

## Validation
- `python3 -m py_compile wattnode/build_linux.py wattnode/wattnode_gui.py`

Closes #138

**Payout Wallet**: HVLdjyDJCd7iwjLAkhAK1WPxuWfsDiiugbN8DMfoLbjP
