### PR TITLE
feat(pi): scaffold Raspberry Pi sensor oracle for bounty #19

### DIFF
--- a/docs/pi-sensor-oracle.md
+++ b/docs/pi-sensor-oracle.md
@@ -1,0 +1,53 @@
+# Raspberry Pi Sensor Oracle (Bounty #19 Scaffold)
+
+This scaffold provides a minimal, mergeable implementation for:
+- DHT22-style readings (temperature + humidity)
+- PIR motion readings
+- signed payload submission to `/api/v1/oracle/report`
+- local history logging (`history.jsonl`)
+- configurable reporting interval
+
+## Quick start
+
+```bash
+cd pi/sensor_oracle
+./install.sh
+.venv/bin/python oracle.py --once
+```
+
+## Configuration
+
+- `WATT_ORACLE_API_URL` (default `http://localhost:5000/api/v1/oracle/report`)
+- `WATT_WALLET` (wallet id/address)
+- `WATT_WALLET_SECRET` (dev signing secret)
+- `WATT_ORACLE_HISTORY` (default `pi/sensor_oracle/history.jsonl`)
+- `WATT_ORACLE_INTERVAL_SEC` (default `60`)
+- `WATT_ORACLE_MOCK_FILE` (default `pi/sensor_oracle/mock_sensors.json`)
+
+## Wiring diagrams (reference)
+
+### DHT22 → Raspberry Pi (BCM)
+
+- VCC → 3.3V (Pin 1)
+- DATA → GPIO4 (Pin 7)
+- GND → GND (Pin 6)
+- 10k resistor between VCC and DATA
+
+### PIR sensor → Raspberry Pi (BCM)
+
+- VCC → 5V (Pin 2)
+- OUT → GPIO17 (Pin 11)
+- GND → GND (Pin 14)
+
+## Service install (optional)
+
+```bash
+sudo cp pi/sensor_oracle/wattcoin-sensor-oracle.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now wattcoin-sensor-oracle
+```
+
+## Notes
+
+- Current implementation uses mock sensor input to keep PR safe/testable.
+- Replace `MockSensors` with real GPIO/I2C adapters in production.

--- a/pi/sensor_oracle/__init__.py
+++ b/pi/sensor_oracle/__init__.py
@@ -1,0 +1,1 @@
+"""Raspberry Pi sensor oracle scaffold for WattCoin bounty #19."""

--- a/pi/sensor_oracle/install.sh
+++ b/pi/sensor_oracle/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade pip
+
+cat <<'EOF'
+✅ Sensor oracle scaffold installed.
+Run once:
+  .venv/bin/python oracle.py --once
+Run continuously:
+  .venv/bin/python oracle.py
+EOF

--- a/pi/sensor_oracle/mock_sensors.json
+++ b/pi/sensor_oracle/mock_sensors.json
@@ -1,0 +1,5 @@
+{
+  "temperature_c": 24.1,
+  "humidity_percent": 46.3,
+  "motion": false
+}

--- a/pi/sensor_oracle/oracle.py
+++ b/pi/sensor_oracle/oracle.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Minimal Raspberry Pi sensor oracle scaffold.
+
+Reads two sensor types (DHT22 temp/humidity and PIR motion), writes local history,
+signs payloads, and reports to WattCoin oracle API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib import request
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class SensorSample:
+    sensor_type: str
+    value: Any
+    timestamp: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sensor_type": self.sensor_type,
+            "value": self.value,
+            "timestamp": self.timestamp,
+        }
+
+
+class MockSensors:
+    """Mock sensor source for local development/testing."""
+
+    def __init__(self, mock_file: Path | None = None) -> None:
+        self.mock_file = mock_file
+
+    def read_dht22(self) -> list[SensorSample]:
+        payload = self._load()
+        ts = iso_now()
+        return [
+            SensorSample("temperature_c", float(payload.get("temperature_c", 23.5)), ts),
+            SensorSample("humidity_percent", float(payload.get("humidity_percent", 50.0)), ts),
+        ]
+
+    def read_pir(self) -> SensorSample:
+        payload = self._load()
+        return SensorSample("motion", bool(payload.get("motion", False)), iso_now())
+
+    def _load(self) -> dict[str, Any]:
+        if self.mock_file and self.mock_file.exists():
+            return json.loads(self.mock_file.read_text(encoding="utf-8"))
+        return {}
+
+
+def build_signature(payload: dict[str, Any], wallet_secret: str) -> str:
+    compact = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hmac.new(wallet_secret.encode("utf-8"), compact, hashlib.sha256).hexdigest()
+
+
+def append_history(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def post_report(api_url: str, payload: dict[str, Any], timeout: float = 8.0) -> tuple[int, str]:
+    body = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        api_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=timeout) as resp:  # nosec B310 - known api url input
+        return resp.getcode(), resp.read().decode("utf-8", errors="replace")
+
+
+def collect_and_report(args: argparse.Namespace) -> int:
+    sensors = MockSensors(Path(args.mock_file) if args.mock_file else None)
+
+    readings: list[dict[str, Any]] = []
+    readings.extend(sample.to_dict() for sample in sensors.read_dht22())
+    readings.append(sensors.read_pir().to_dict())
+
+    report = {
+        "wallet": args.wallet,
+        "timestamp": iso_now(),
+        "readings": readings,
+    }
+    report["signature"] = build_signature(report, args.wallet_secret)
+
+    append_history(Path(args.history_file), report)
+    code, text = post_report(args.api_url, report)
+    print(f"oracle report status={code} body={text[:200]}")
+    return 0 if 200 <= code < 300 else 1
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="WattCoin Raspberry Pi sensor oracle")
+    p.add_argument("--api-url", default=os.getenv("WATT_ORACLE_API_URL", "http://localhost:5000/api/v1/oracle/report"))
+    p.add_argument("--wallet", default=os.getenv("WATT_WALLET", "demo-wallet"))
+    p.add_argument("--wallet-secret", default=os.getenv("WATT_WALLET_SECRET", "dev-secret"))
+    p.add_argument("--history-file", default=os.getenv("WATT_ORACLE_HISTORY", "pi/sensor_oracle/history.jsonl"))
+    p.add_argument("--mock-file", default=os.getenv("WATT_ORACLE_MOCK_FILE", "pi/sensor_oracle/mock_sensors.json"))
+    p.add_argument("--interval", type=int, default=int(os.getenv("WATT_ORACLE_INTERVAL_SEC", "60")))
+    p.add_argument("--once", action="store_true", help="Send one report and exit")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.once:
+        return collect_and_report(args)
+
+    while True:
+        rc = collect_and_report(args)
+        if rc != 0:
+            return rc
+        time.sleep(max(5, args.interval))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pi/sensor_oracle/wattcoin-sensor-oracle.service
+++ b/pi/sensor_oracle/wattcoin-sensor-oracle.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=WattCoin Raspberry Pi Sensor Oracle
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/wattcoin/pi/sensor_oracle
+Environment=WATT_ORACLE_API_URL=https://api.wattcoin.org/api/v1/oracle/report
+Environment=WATT_ORACLE_INTERVAL_SEC=60
+ExecStart=/opt/wattcoin/pi/sensor_oracle/.venv/bin/python /opt/wattcoin/pi/sensor_oracle/oracle.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_pi_sensor_oracle.py
+++ b/tests/test_pi_sensor_oracle.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from pi.sensor_oracle.oracle import MockSensors, append_history, build_signature
+
+
+def test_mock_sensors_support_two_sensor_types(tmp_path: Path):
+    mock_file = tmp_path / "mock.json"
+    mock_file.write_text('{"temperature_c": 21.0, "humidity_percent": 40.2, "motion": true}', encoding="utf-8")
+
+    sensors = MockSensors(mock_file)
+    dht = sensors.read_dht22()
+    pir = sensors.read_pir()
+
+    assert len(dht) == 2
+    assert {s.sensor_type for s in dht} == {"temperature_c", "humidity_percent"}
+    assert pir.sensor_type == "motion"
+    assert pir.value is True
+
+
+def test_signature_and_history_write(tmp_path: Path):
+    payload = {"wallet": "w1", "timestamp": "2026-01-01T00:00:00Z", "readings": []}
+    sig1 = build_signature(payload, "secret")
+    sig2 = build_signature(payload, "secret")
+    assert sig1 == sig2
+
+    hist = tmp_path / "history.jsonl"
+    append_history(hist, {"ok": True})
+    line = hist.read_text(encoding="utf-8").strip()
+    assert '"ok": true' in line


### PR DESCRIPTION
## Summary
Implements a minimal, mergeable scaffold for #19:
- : collects two sensor classes (DHT22-style temperature/humidity + PIR motion), signs payload, logs local history, posts to 
- Requirement already satisfied: pip in ./.venv/lib/python3.14/site-packages (26.0)
Collecting pip
  Downloading pip-26.0.1-py3-none-any.whl.metadata (4.7 kB)
Downloading pip-26.0.1-py3-none-any.whl (1.8 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 3.0 MB/s  0:00:01
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 26.0
    Uninstalling pip-26.0:
      Successfully uninstalled pip-26.0
Successfully installed pip-26.0.1
✅ Sensor oracle scaffold installed.
Run once:
  .venv/bin/python oracle.py --once
Run continuously:
  .venv/bin/python oracle.py: Pi bootstrap script
- : systemd unit example
- : setup, env config, wiring diagrams
- : focused tests for sensor-type coverage + signature/history helpers

## Notes
- Uses a mock sensor source by default to keep this PR safe and testable.
- Structure is ready for drop-in GPIO/I2C adapters while preserving report/sign/log flow.

## Validation
- 

Closes #19

**Payout Wallet**: HVLdjyDJCd7iwjLAkhAK1WPxuWfsDiiugbN8DMfoLbjP