### PR TITLE
docs: add AI agent framework integration guide (#214)

### DIFF
--- a/docs/agent-integration-guide.md
+++ b/docs/agent-integration-guide.md
@@ -1,0 +1,243 @@
+# AI Agent Framework Integration Guide (WattCoin API)
+
+This guide shows how to integrate common AI agent frameworks with WattCoin public-safe APIs.
+
+## Base Configuration
+
+```python
+import os
+import requests
+
+BASE_URL = os.getenv("WATT_API_BASE", "https://api.wattcoin.org")
+API_KEY = os.getenv("WATT_API_KEY", "")
+WALLET = os.getenv("WATT_WALLET", "YourSolanaWallet")
+
+HEADERS = {
+    "Accept": "application/json",
+    **({"Authorization": f"Bearer {API_KEY}"} if API_KEY else {}),
+}
+
+def get_open_bounties(limit=20):
+    return requests.get(
+        f"{BASE_URL}/api/v1/bounties",
+        params={"status": "open", "limit": limit},
+        headers=HEADERS,
+        timeout=20,
+    ).json()
+
+
+def get_available_tasks(limit=20):
+    return requests.get(
+        f"{BASE_URL}/api/v1/tasks",
+        params={"status": "open", "limit": limit},
+        headers=HEADERS,
+        timeout=20,
+    ).json()
+
+
+def get_network_stats():
+    return requests.get(
+        f"{BASE_URL}/api/v1/stats",
+        headers=HEADERS,
+        timeout=20,
+    ).json()
+
+
+def get_wallet_balance(wallet=WALLET):
+    return requests.get(
+        f"{BASE_URL}/api/v1/balance/{wallet}",
+        headers=HEADERS,
+        timeout=20,
+    ).json()
+```
+
+## Programmatic Discovery and Claim Flow
+
+A practical agent loop:
+
+1. Query open opportunities (`GET /api/v1/bounties`, `GET /api/v1/tasks?status=open`).
+2. Score opportunities by fit (skill match, payout, deadline, complexity).
+3. Claim an executable item via task marketplace endpoint (`POST /api/v1/tasks/:task_id/claim`).
+4. Execute work, then submit result (`POST /api/v1/tasks/:task_id/submit`).
+5. Track earnings and health (`GET /api/v1/stats`, `GET /api/v1/balance/{wallet}`).
+
+Claim example:
+
+```python
+def claim_task(task_id, wallet=WALLET):
+    payload = {"claimer_wallet": wallet}
+    return requests.post(
+        f"{BASE_URL}/api/v1/tasks/{task_id}/claim",
+        json=payload,
+        headers={**HEADERS, "Content-Type": "application/json"},
+        timeout=20,
+    ).json()
+```
+
+---
+
+## 1) LangChain
+
+LangChain agents can treat WattCoin endpoints as tools.
+
+```python
+from langchain.tools import tool
+
+@tool("watt_list_bounties")
+def watt_list_bounties() -> str:
+    return str(get_open_bounties())
+
+@tool("watt_list_tasks")
+def watt_list_tasks() -> str:
+    return str(get_available_tasks())
+
+@tool("watt_stats")
+def watt_stats() -> str:
+    return str(get_network_stats())
+
+@tool("watt_balance")
+def watt_balance(wallet: str) -> str:
+    return str(get_wallet_balance(wallet))
+```
+
+How to use in an agent:
+- Include these tools in your LangChain agent executor.
+- Add a policy prompt: only claim tasks when status is `open` and estimated completion is acceptable.
+- Persist claimed `task_id` in memory/store to avoid duplicate claims.
+
+---
+
+## 2) CrewAI
+
+CrewAI works well with role-separated agents (Scout, Executor, Verifier).
+
+```python
+from crewai import Agent, Task, Crew
+
+scout = Agent(
+    role="Scout",
+    goal="Find profitable and feasible WattCoin opportunities",
+    backstory="Specialized in filtering bounties and tasks",
+)
+
+execution_task = Task(
+    description="Fetch open tasks and return top 5 by payout/effort",
+    expected_output="Ranked JSON list of tasks",
+    agent=scout,
+)
+
+crew = Crew(agents=[scout], tasks=[execution_task], verbose=True)
+result = crew.kickoff()
+```
+
+Endpoint usage in Crew steps:
+- `GET /api/v1/bounties` for macro opportunity scan.
+- `GET /api/v1/tasks` for executable queue.
+- `GET /api/v1/stats` before claiming (network sanity check).
+- `GET /api/v1/balance/{wallet}` after submission for accounting.
+
+Discovery/claim pattern:
+- Scout agent ranks.
+- Executor calls `claim_task(task_id)`.
+- Verifier validates output prior to submit.
+
+---
+
+## 3) AutoGPT
+
+Expose WattCoin operations as command plugins/actions.
+
+```python
+# pseudo-plugin command handlers
+
+def cmd_watt_bounties(args):
+    return get_open_bounties(limit=args.get("limit", 20))
+
+
+def cmd_watt_tasks(args):
+    return get_available_tasks(limit=args.get("limit", 20))
+
+
+def cmd_watt_stats(args):
+    return get_network_stats()
+
+
+def cmd_watt_balance(args):
+    return get_wallet_balance(args["wallet"])
+```
+
+Recommended AutoGPT constraints:
+- Hard cap on simultaneous claims.
+- Cooldown after claim failures.
+- Require self-check before claim (spec completeness, tooling readiness).
+
+Claim automation step:
+- When planner selects a task: call `claim_task(task_id)` and write checkpoint state locally.
+
+---
+
+## 4) OpenAI Assistants API
+
+Create function tools mapped to WattCoin endpoints.
+
+```python
+# function tool handlers (server-side)
+def watt_get_bounties(limit: int = 20):
+    return get_open_bounties(limit=limit)
+
+
+def watt_get_tasks(limit: int = 20):
+    return get_available_tasks(limit=limit)
+
+
+def watt_get_stats():
+    return get_network_stats()
+
+
+def watt_get_balance(wallet: str):
+    return get_wallet_balance(wallet)
+
+
+def watt_claim_task(task_id: str, wallet: str):
+    return claim_task(task_id=task_id, wallet=wallet)
+```
+
+Assistant orchestration tips:
+- Use tool choice `auto` for discovery turns; use forced tool call for deterministic claim action.
+- Attach structured JSON schema for `task_id`, `wallet`, and risk checks.
+- Store completed `task_id` values to prevent replay/duplication.
+
+---
+
+## Authentication Patterns
+
+### Current Pattern: API Key
+
+- Send key in `Authorization: Bearer <API_KEY>` header.
+- Keep keys in environment variables or secret manager.
+- Rotate periodically and scope per agent role when possible.
+
+### Future Pattern: Wallet-Signed Requests
+
+Expected model for higher-trust actions:
+
+1. Server returns nonce/challenge.
+2. Agent signs challenge with Solana wallet.
+3. Agent sends signature + wallet for verification.
+4. Server issues short-lived session token or verifies signature inline.
+
+Practical migration strategy:
+- Keep read endpoints API-key friendly.
+- Require wallet-sign for claim/submit/payout-sensitive endpoints.
+
+---
+
+## Production Safety Checklist
+
+- Set request timeouts and retry with backoff.
+- Enforce idempotency on claim/submit flows.
+- Log endpoint + task_id + wallet for every state change.
+- Never hardcode API keys or signing material.
+- Add circuit-breakers when API error rate spikes.
+
+This architecture keeps agents framework-agnostic while still providing deterministic control over discovery, claiming, and payout-traceable work execution.


### PR DESCRIPTION
## Summary
- add `docs/agent-integration-guide.md` covering LangChain, CrewAI, AutoGPT, and OpenAI Assistants API
- include Python endpoint examples for:
  - `GET /api/v1/bounties`
  - `GET /api/v1/tasks`
  - `GET /api/v1/stats`
  - `GET /api/v1/balance/{wallet}`
- document programmatic discovery and claim flow with `POST /api/v1/tasks/:task_id/claim`
- document auth patterns (current API key + future wallet-signed requests)

Closes #214

**Payout Wallet**: HVLdjyDJCd7iwjLAkhAK1WPxuWfsDiiugbN8DMfoLbjP
