### PR TITLE
feat(wattnode): add Linux GUI build script + docs refresh (#138)

### DIFF
--- a/wattnode/build_linux.py
+++ b/wattnode/build_linux.py
@@ -8,9 +8,12 @@ Outputs:
 
 from __future__ import annotations
 
+import importlib.util
 import shutil
 import subprocess
+import sys
 from pathlib import Path
+from typing import NoReturn
 
 ROOT = Path(__file__).resolve().parent
 DIST = ROOT / "dist"
@@ -18,9 +21,22 @@ APPDIR = ROOT / "AppDir"
 APPIMAGE_TOOL = shutil.which("appimagetool")
 
 
+def fail(msg: str) -> NoReturn:
+    print(f"✗ {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
 def run(cmd: list[str]) -> None:
     print("+", " ".join(cmd))
-    subprocess.run(cmd, cwd=ROOT, check=True)
+    try:
+        subprocess.run(cmd, cwd=ROOT, check=True)
+    except subprocess.CalledProcessError as exc:
+        fail(f"Command failed ({exc.returncode}): {' '.join(cmd)}")
+
+
+def ensure_exists(path: Path, label: str) -> None:
+    if not path.exists():
+        fail(f"Missing required {label}: {path}")
 
 
 def ensure_desktop_entry() -> Path:
@@ -46,28 +62,47 @@ def ensure_desktop_entry() -> Path:
 
 def stage_appdir() -> None:
     if APPDIR.exists():
-        shutil.rmtree(APPDIR)
-    (APPDIR / "usr" / "bin").mkdir(parents=True, exist_ok=True)
-    (APPDIR / "usr" / "share" / "icons" / "hicolor" / "256x256" / "apps").mkdir(
-        parents=True, exist_ok=True
-    )
+        try:
+            shutil.rmtree(APPDIR)
+        except OSError as exc:
+            fail(f"Failed to clean AppDir: {exc}")
+
+    try:
+        (APPDIR / "usr" / "bin").mkdir(parents=True, exist_ok=True)
+        (APPDIR / "usr" / "share" / "icons" / "hicolor" / "256x256" / "apps").mkdir(
+            parents=True, exist_ok=True
+        )
+    except OSError as exc:
+        fail(f"Failed to create AppDir structure: {exc}")
 
     binary_src = DIST / "WattNode"
+    ensure_exists(binary_src, "binary")
     binary_dst = APPDIR / "usr" / "bin" / "WattNode"
-    shutil.copy2(binary_src, binary_dst)
 
     logo_src = ROOT / "assets" / "logo.png"
+    ensure_exists(logo_src, "logo")
     logo_dst = APPDIR / "usr" / "share" / "icons" / "hicolor" / "256x256" / "apps" / "wattnode.png"
-    shutil.copy2(logo_src, logo_dst)
 
-    apprun = APPDIR / "AppRun"
-    apprun.write_text("#!/bin/sh\nexec \"$APPDIR/usr/bin/WattNode\" \"$@\"\n", encoding="utf-8")
-    apprun.chmod(0o755)
+    try:
+        shutil.copy2(binary_src, binary_dst)
+        shutil.copy2(logo_src, logo_dst)
 
-    ensure_desktop_entry()
+        apprun = APPDIR / "AppRun"
+        apprun.write_text("#!/bin/sh\nexec \"$APPDIR/usr/bin/WattNode\" \"$@\"\n", encoding="utf-8")
+        apprun.chmod(0o755)
+
+        ensure_desktop_entry()
+    except OSError as exc:
+        fail(f"Failed during AppDir staging: {exc}")
 
 
 def build_pyinstaller() -> None:
+    if importlib.util.find_spec("PyInstaller") is None:
+        fail("PyInstaller is not installed. Install with: pip install pyinstaller")
+
+    ensure_exists(ROOT / "wattnode_gui.py", "GUI entrypoint")
+    ensure_exists(ROOT / "assets" / "logo.png", "logo")
+
     run(
         [
             "python3",
@@ -90,9 +125,13 @@ def build_appimage() -> Path | None:
         print("! appimagetool not found; skip AppImage packaging")
         return None
 
+    tool_path = Path(APPIMAGE_TOOL)
+    if not tool_path.exists() or not tool_path.is_file():
+        fail(f"Invalid appimagetool path: {tool_path}")
+
     stage_appdir()
     output = DIST / "WattNode.AppImage"
-    run([APPIMAGE_TOOL, str(APPDIR), str(output)])
+    run([str(tool_path), str(APPDIR), str(output)])
     print(f"✓ AppImage created: {output}")
     return output
 


### PR DESCRIPTION
## Summary
Adds a focused Linux packaging path for WattNode GUI in a minimal, mergeable change set:

- `wattnode/build_linux.py` build script for Linux one-file binary (`dist/WattNode`)
- optional AppImage packaging when `appimagetool` is available (`dist/WattNode.AppImage`)
- `wattnode/README_GUI.md` updates for Linux quickstart and build instructions

## Notes
- Uses `subprocess.run(..., check=True)` with explicit argv (no `shell=True`).
- Keeps current runtime behavior unchanged; this only adds build + docs capability for Linux packaging.

## Validation
- `python3 -m py_compile wattnode/build_linux.py`

Closes #138

**Payout Wallet**: HVLdjyDJCd7iwjLAkhAK1WPxuWfsDiiugbN8DMfoLbjP