### PR TITLE
feat: add Solana memo parser for WATT payment reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,18 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 ├── admin_blueprint.py # Admin dashboard
 ├── skills/wattcoin/  # OpenClaw skill
 ├── docs/             # API documentation
+├── tools/            # Contributor utilities (memo parser, tests)
 ├── deployment/       # Launch scripts
 └── WHITEPAPER.md     # Technical specification
 ```
+
+## 🧰 Contributor Utility: Solana Memo Parser
+
+Need to audit payout memos by category? Use `tools/memo_parser.py`.
+
+- Documentation: [docs/WATT_MEMO_PARSER.md](docs/WATT_MEMO_PARSER.md)
+- Sample output: [docs/samples/watt_memo_report.sample.json](docs/samples/watt_memo_report.sample.json)
+
 
 ## 🔐 Wallets
 

--- a/docs/WATT_MEMO_PARSER.md
+++ b/docs/WATT_MEMO_PARSER.md
@@ -1,0 +1,60 @@
+# WATT Memo Parser
+
+`tools/memo_parser.py` scans Solana transactions for the WATT mint, extracts memo data, classifies payment types, and produces a JSON report.
+
+## Features
+
+- Configurable Solana RPC endpoint (`--rpc-url`)
+- Scans signatures for the WATT mint address
+- Extracts memo data from top-level + inner instructions
+- Categorizes memo formats into:
+  - `bounty_payment`
+  - `swarmsolve_payment`
+  - `swarmsolve_refund`
+  - `task_payout`
+  - `wsi_payout`
+  - `other`
+- Outputs:
+  - detailed transaction list
+  - category breakdown counts + total WATT
+  - overall total WATT
+- Optional filters:
+  - date range (`--start-date`, `--end-date`)
+  - wallet (`--wallet`)
+
+## Usage
+
+```bash
+python tools/memo_parser.py \
+  --rpc-url https://api.mainnet-beta.solana.com \
+  --mint Gpmbh4PoQnL1kNgpMYDED3iv4fczcr7d3qNBLf8rpump \
+  --max-signatures 250 \
+  --start-date 2026-03-01T00:00:00Z \
+  --end-date 2026-03-04T00:00:00Z \
+  --output docs/samples/watt_memo_report.sample.json
+```
+
+## Output Schema (high-level)
+
+```json
+{
+  "generated_at": "...",
+  "rpc_url": "...",
+  "mint": "...",
+  "filters": {"...": "..."},
+  "scanned_signatures": 250,
+  "matched_transactions": 42,
+  "total_watt": 13850.0,
+  "category_breakdown": {
+    "bounty_payment": {"count": 11, "total_watt": 9200.0},
+    "task_payout": {"count": 8, "total_watt": 2200.0}
+  },
+  "transactions": [{"signature": "...", "memo": "...", "category": "...", "amount_watt": 250.0}]
+}
+```
+
+## Tests
+
+```bash
+python -m unittest tools/tests/test_memo_parser.py
+```

--- a/docs/samples/watt_memo_report.sample.json
+++ b/docs/samples/watt_memo_report.sample.json
@@ -1,0 +1,94 @@
+{
+  "generated_at": "2026-03-04T00:00:00+00:00",
+  "rpc_url": "https://api.mainnet-beta.solana.com",
+  "mint": "Gpmbh4PoQnL1kNgpMYDED3iv4fczcr7d3qNBLf8rpump",
+  "filters": {
+    "start_date_epoch": 1741046400,
+    "end_date_epoch": 1741132800,
+    "wallet": null,
+    "max_signatures": 200
+  },
+  "scanned_signatures": 200,
+  "matched_transactions": 4,
+  "total_watt": 4300.0,
+  "category_breakdown": {
+    "bounty_payment": {
+      "count": 1,
+      "total_watt": 2500.0
+    },
+    "task_payout": {
+      "count": 1,
+      "total_watt": 1200.0
+    },
+    "swarmsolve_payment": {
+      "count": 1,
+      "total_watt": 500.0
+    },
+    "other": {
+      "count": 1,
+      "total_watt": 100.0
+    }
+  },
+  "transactions": [
+    {
+      "signature": "EXAMPLE_SIG_1",
+      "slot": 332211445,
+      "block_time": 1741120000,
+      "memo": "WattCoin Bounty | PR #98 | Issue #240 | Score: 9/10 | 2500 WATT",
+      "all_memos": [
+        "WattCoin Bounty | PR #98 | Issue #240 | Score: 9/10 | 2500 WATT"
+      ],
+      "category": "bounty_payment",
+      "amount_watt": 2500.0,
+      "accounts": [
+        "wallet_sender",
+        "wallet_receiver"
+      ]
+    },
+    {
+      "signature": "EXAMPLE_SIG_2",
+      "slot": 332211111,
+      "block_time": 1741112000,
+      "memo": "task:payout:task_11fa544b80b7",
+      "all_memos": [
+        "task:payout:task_11fa544b80b7"
+      ],
+      "category": "task_payout",
+      "amount_watt": 1200.0,
+      "accounts": [
+        "wallet_a",
+        "wallet_b"
+      ]
+    },
+    {
+      "signature": "EXAMPLE_SIG_3",
+      "slot": 332210999,
+      "block_time": 1741108000,
+      "memo": "swarmsolve:payment:SOLUTION_123",
+      "all_memos": [
+        "swarmsolve:payment:SOLUTION_123"
+      ],
+      "category": "swarmsolve_payment",
+      "amount_watt": 500.0,
+      "accounts": [
+        "wallet_c",
+        "wallet_d"
+      ]
+    },
+    {
+      "signature": "EXAMPLE_SIG_4",
+      "slot": 332210777,
+      "block_time": 1741104000,
+      "memo": "manual adjustment",
+      "all_memos": [
+        "manual adjustment"
+      ],
+      "category": "other",
+      "amount_watt": 100.0,
+      "accounts": [
+        "wallet_x",
+        "wallet_y"
+      ]
+    }
+  ]
+}

--- a/tools/memo_parser.py
+++ b/tools/memo_parser.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Parse and categorize WATT payment memos from Solana transactions.
+
+Example:
+  python tools/memo_parser.py --max-signatures 200 --output docs/samples/watt_memo_report.sample.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+import time
+
+DEFAULT_RPC_URL = "https://api.mainnet-beta.solana.com"
+DEFAULT_WATT_MINT = "Gpmbh4PoQnL1kNgpMYDED3iv4fczcr7d3qNBLf8rpump"
+DEFAULT_MEMO_PROGRAM = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+
+
+def parse_date_to_epoch(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp())
+
+
+def classify_memo(memo: str) -> str:
+    normalized = memo.strip().lower()
+    if normalized.startswith("wattcoin bounty"):
+        return "bounty_payment"
+    if normalized.startswith("swarmsolve:payment:"):
+        return "swarmsolve_payment"
+    if normalized.startswith("swarmsolve:expired:"):
+        return "swarmsolve_refund"
+    if normalized.startswith("task:payout:"):
+        return "task_payout"
+    if normalized.startswith("wsi:payout:") or "wsi" in normalized and "payout" in normalized:
+        return "wsi_payout"
+    return "other"
+
+
+def _extract_keys(message: Dict[str, Any]) -> List[str]:
+    keys = message.get("accountKeys") or []
+    result: List[str] = []
+    for key in keys:
+        if isinstance(key, str):
+            result.append(key)
+        elif isinstance(key, dict):
+            pubkey = key.get("pubkey")
+            if pubkey:
+                result.append(pubkey)
+    return result
+
+
+def _memo_from_instruction(instruction: Dict[str, Any]) -> Optional[str]:
+    parsed = instruction.get("parsed")
+    if isinstance(parsed, str):
+        return parsed
+    if isinstance(parsed, dict):
+        if parsed.get("type") == "memo":
+            value = parsed.get("info")
+            if isinstance(value, str):
+                return value
+            if isinstance(value, dict):
+                return value.get("memo")
+        memo = parsed.get("memo")
+        if isinstance(memo, str):
+            return memo
+
+    if instruction.get("programId") == DEFAULT_MEMO_PROGRAM:
+        data = instruction.get("data")
+        if isinstance(data, str):
+            return data
+
+    if instruction.get("program") in {"spl-memo", "memo"}:
+        data = instruction.get("data")
+        if isinstance(data, str):
+            return data
+
+    return None
+
+
+def extract_memo_texts(tx: Dict[str, Any]) -> List[str]:
+    transaction = tx.get("transaction") or {}
+    message = transaction.get("message") or {}
+    meta = tx.get("meta") or {}
+
+    instructions: List[Dict[str, Any]] = list(message.get("instructions") or [])
+    for inner in meta.get("innerInstructions") or []:
+        instructions.extend(inner.get("instructions") or [])
+
+    memos: List[str] = []
+    for instruction in instructions:
+        memo = _memo_from_instruction(instruction)
+        if memo:
+            memos.append(memo)
+    return memos
+
+
+def extract_watt_amount(tx: Dict[str, Any], mint: str) -> float:
+    """Estimate transferred WATT using token balance deltas.
+
+    We sum all positive deltas for balances matching the target mint.
+    """
+    meta = tx.get("meta") or {}
+    pre = meta.get("preTokenBalances") or []
+    post = meta.get("postTokenBalances") or []
+
+    decimals = None
+    pre_map: Dict[int, int] = {}
+    post_map: Dict[int, int] = {}
+
+    for item in pre:
+        if item.get("mint") != mint:
+            continue
+        idx = item.get("accountIndex")
+        amount = int((item.get("uiTokenAmount") or {}).get("amount") or 0)
+        pre_map[idx] = amount
+        decimals = (item.get("uiTokenAmount") or {}).get("decimals", decimals)
+
+    for item in post:
+        if item.get("mint") != mint:
+            continue
+        idx = item.get("accountIndex")
+        amount = int((item.get("uiTokenAmount") or {}).get("amount") or 0)
+        post_map[idx] = amount
+        decimals = (item.get("uiTokenAmount") or {}).get("decimals", decimals)
+
+    if decimals is None:
+        return 0.0
+
+    total_raw_increase = 0
+    for idx in set(pre_map) | set(post_map):
+        before = pre_map.get(idx, 0)
+        after = post_map.get(idx, 0)
+        delta = after - before
+        if delta > 0:
+            total_raw_increase += delta
+
+    scale = Decimal(10) ** Decimal(decimals)
+    return float((Decimal(total_raw_increase) / scale).quantize(Decimal("0.000001")))
+
+
+def tx_mentions_wallet(tx: Dict[str, Any], wallet: Optional[str]) -> bool:
+    if not wallet:
+        return True
+    message = (tx.get("transaction") or {}).get("message") or {}
+    return wallet in _extract_keys(message)
+
+
+class SolanaRpcClient:
+    def __init__(self, rpc_url: str, timeout: int = 30) -> None:
+        self.rpc_url = rpc_url
+        self.timeout = timeout
+        self.session = requests.Session()
+
+    def call(self, method: str, params: List[Any]) -> Any:
+        retries = 3
+        delay_seconds = 1.0
+
+        for attempt in range(1, retries + 1):
+            response = self.session.post(
+                self.rpc_url,
+                json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
+                timeout=self.timeout,
+            )
+
+            if response.status_code == 429 and attempt < retries:
+                time.sleep(delay_seconds)
+                delay_seconds *= 2
+                continue
+
+            response.raise_for_status()
+            payload = response.json()
+            if "error" in payload:
+                raise RuntimeError(f"RPC error for {method}: {payload['error']}")
+            return payload.get("result")
+
+        raise RuntimeError(f"RPC call failed for {method} after {retries} attempts")
+
+    def get_signatures_for_address(self, address: str, limit: int, before: Optional[str] = None) -> List[Dict[str, Any]]:
+        config: Dict[str, Any] = {"limit": limit}
+        if before:
+            config["before"] = before
+        return self.call("getSignaturesForAddress", [address, config])
+
+    def get_transaction(self, signature: str) -> Optional[Dict[str, Any]]:
+        return self.call(
+            "getTransaction",
+            [signature, {"encoding": "jsonParsed", "maxSupportedTransactionVersion": 0}],
+        )
+
+
+def iter_signatures(
+    client: SolanaRpcClient,
+    address: str,
+    max_signatures: int,
+) -> Iterable[Dict[str, Any]]:
+    fetched = 0
+    before: Optional[str] = None
+    while fetched < max_signatures:
+        remaining = max_signatures - fetched
+        page = client.get_signatures_for_address(address, limit=min(1000, remaining), before=before)
+        if not page:
+            break
+
+        for item in page:
+            yield item
+            fetched += 1
+            if fetched >= max_signatures:
+                break
+
+        before = page[-1].get("signature")
+
+
+def build_report(
+    client: SolanaRpcClient,
+    mint: str,
+    max_signatures: int,
+    start_epoch: Optional[int],
+    end_epoch: Optional[int],
+    wallet_filter: Optional[str],
+) -> Dict[str, Any]:
+    transactions: List[Dict[str, Any]] = []
+    category_summary: Dict[str, Dict[str, Any]] = defaultdict(lambda: {"count": 0, "total_watt": 0.0})
+
+    scanned = 0
+    for item in iter_signatures(client, mint, max_signatures=max_signatures):
+        scanned += 1
+        signature = item.get("signature")
+        block_time = item.get("blockTime")
+
+        if start_epoch and (block_time is None or block_time < start_epoch):
+            continue
+        if end_epoch and (block_time is None or block_time > end_epoch):
+            continue
+
+        tx = client.get_transaction(signature)
+        if not tx:
+            continue
+        if not tx_mentions_wallet(tx, wallet_filter):
+            continue
+
+        memos = extract_memo_texts(tx)
+        if not memos:
+            continue
+
+        amount = extract_watt_amount(tx, mint)
+        memo = memos[0]
+        category = classify_memo(memo)
+
+        record = {
+            "signature": signature,
+            "slot": tx.get("slot"),
+            "block_time": block_time,
+            "memo": memo,
+            "all_memos": memos,
+            "category": category,
+            "amount_watt": amount,
+            "accounts": _extract_keys((tx.get("transaction") or {}).get("message") or {}),
+        }
+        transactions.append(record)
+
+        category_summary[category]["count"] += 1
+        category_summary[category]["total_watt"] = round(category_summary[category]["total_watt"] + amount, 6)
+
+    total_watt = round(sum(entry["total_watt"] for entry in category_summary.values()), 6)
+    category_breakdown = {key: value for key, value in sorted(category_summary.items())}
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "rpc_url": client.rpc_url,
+        "mint": mint,
+        "filters": {
+            "start_date_epoch": start_epoch,
+            "end_date_epoch": end_epoch,
+            "wallet": wallet_filter,
+            "max_signatures": max_signatures,
+        },
+        "scanned_signatures": scanned,
+        "matched_transactions": len(transactions),
+        "total_watt": total_watt,
+        "category_breakdown": category_breakdown,
+        "transactions": transactions,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Scan WATT transactions and parse payment memos")
+    parser.add_argument("--rpc-url", default=DEFAULT_RPC_URL, help="Solana RPC URL")
+    parser.add_argument("--mint", default=DEFAULT_WATT_MINT, help="WATT mint address")
+    parser.add_argument("--wallet", help="Filter transactions involving a wallet")
+    parser.add_argument("--start-date", help="ISO date/time, e.g. 2026-03-01 or 2026-03-01T00:00:00Z")
+    parser.add_argument("--end-date", help="ISO date/time")
+    parser.add_argument("--max-signatures", type=int, default=500, help="Max mint signatures to inspect")
+    parser.add_argument("--output", default="watt_memo_report.json", help="Output JSON path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    start_epoch = parse_date_to_epoch(args.start_date)
+    end_epoch = parse_date_to_epoch(args.end_date)
+
+    client = SolanaRpcClient(args.rpc_url)
+    report = build_report(
+        client=client,
+        mint=args.mint,
+        max_signatures=args.max_signatures,
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        wallet_filter=args.wallet,
+    )
+
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2, ensure_ascii=False)
+
+    print(f"Report written to {args.output}")
+    print(f"Matched transactions: {report['matched_transactions']}")
+    print(f"Total WATT: {report['total_watt']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/test_memo_parser.py
+++ b/tools/tests/test_memo_parser.py
@@ -1,0 +1,76 @@
+import unittest
+
+from tools.memo_parser import classify_memo, extract_memo_texts, extract_watt_amount, tx_mentions_wallet
+
+
+class MemoParserTests(unittest.TestCase):
+    def test_classify_memo(self):
+        self.assertEqual(classify_memo("WattCoin Bounty | PR #2"), "bounty_payment")
+        self.assertEqual(classify_memo("swarmsolve:payment:abc"), "swarmsolve_payment")
+        self.assertEqual(classify_memo("swarmsolve:expired:abc"), "swarmsolve_refund")
+        self.assertEqual(classify_memo("task:payout:task_123"), "task_payout")
+        self.assertEqual(classify_memo("wsi:payout:job_77"), "wsi_payout")
+        self.assertEqual(classify_memo("unknown format"), "other")
+
+    def test_extract_memo_texts(self):
+        tx = {
+            "transaction": {
+                "message": {
+                    "instructions": [
+                        {"program": "spl-memo", "parsed": "task:payout:TASK_1"},
+                        {"program": "system", "parsed": {"type": "transfer", "info": {}}},
+                    ]
+                }
+            },
+            "meta": {},
+        }
+        self.assertEqual(extract_memo_texts(tx), ["task:payout:TASK_1"])
+
+    def test_extract_watt_amount(self):
+        tx = {
+            "meta": {
+                "preTokenBalances": [
+                    {
+                        "accountIndex": 3,
+                        "mint": "MINT",
+                        "uiTokenAmount": {"amount": "1000000", "decimals": 6},
+                    },
+                    {
+                        "accountIndex": 4,
+                        "mint": "MINT",
+                        "uiTokenAmount": {"amount": "0", "decimals": 6},
+                    },
+                ],
+                "postTokenBalances": [
+                    {
+                        "accountIndex": 3,
+                        "mint": "MINT",
+                        "uiTokenAmount": {"amount": "250000", "decimals": 6},
+                    },
+                    {
+                        "accountIndex": 4,
+                        "mint": "MINT",
+                        "uiTokenAmount": {"amount": "750000", "decimals": 6},
+                    },
+                ],
+            }
+        }
+        self.assertAlmostEqual(extract_watt_amount(tx, "MINT"), 0.75)
+
+    def test_wallet_filter(self):
+        tx = {
+            "transaction": {
+                "message": {
+                    "accountKeys": [
+                        {"pubkey": "wallet_a"},
+                        {"pubkey": "wallet_b"},
+                    ]
+                }
+            }
+        }
+        self.assertTrue(tx_mentions_wallet(tx, "wallet_a"))
+        self.assertFalse(tx_mentions_wallet(tx, "wallet_c"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `tools/memo_parser.py` to scan WATT mint transactions from Solana RPC and extract memo program data
- categorize memos into bounty/task/swarmsolve/WSI buckets and compute per-category + total WATT amounts
- add date range + wallet filters, signature pagination, and JSON report output
- add docs + sample output file and parser unit tests

## Validation
- `python3 -m py_compile tools/memo_parser.py`
- `python3 -m unittest tools/tests/test_memo_parser.py`
- `python3 tools/memo_parser.py --max-signatures 1 --output /tmp/watt_report_test.json`

Fixes #240
